### PR TITLE
Upgrade to rtic 0.6.0 alpha.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic"
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229af1495bf13af8428e8056801c9441c3abee8a96809bb2da6b26b50fef5d63"
+checksum = "74081ae0575d772472789aa6a642a1632303fd64529078d7be06fdcbec31401a"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m 0.7.2",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic-macros"
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7e3faac15e5b3ccd2c1a4160b7f844b24ee767c08dea071c9de8a880f56440"
+checksum = "c537c47b1d14be9bc6781f0bdfc514a043dd03d33796fa4f1052ac8e13c7f7d4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-time"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85ab0d224a6c70f11426a9f04d5f26d250605b80df8fbed197e49d4454f58d7"
+checksum = "86fbafcea0dea120d8ed8af67ddbf82afc031f1d3b064920645db8d061781e2c"
 dependencies = [
  "num",
 ]
@@ -508,18 +508,18 @@ checksum = "8bd58a6949de8ff797a346a28d9f13f7b8f54fa61bb5e3cb0985a4efb497a5ef"
 
 [[package]]
 name = "rtic-monotonic"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3a03d55a8e67949c6940b0b5a7ebacbf1c2c9abd56d72a6c7653d7109f9b01"
+checksum = "9cbf2b6e30a7e6d184be839e0858745fa15ca1af81755c9edcb7b612676604b9"
 dependencies = [
  "embedded-time",
 ]
 
 [[package]]
 name = "rtic-syntax"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f649e066fabcb5158a843a72647e979a622ab2a6f069da1c72f9e33a809ab68"
+checksum = "7676b45b31022d31d9db7efe19a0c0f554e68cf569df389a75664f7b6b7aa8ef"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m-rtic = "0.6.0-alpha.2"
+cortex-m-rtic = "0.6.0-alpha.5"
 cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
-rtic-monotonic = "0.1.0-alpha.0"
+rtic-monotonic = "0.1.0-alpha.2"
 atsamd-hal = { version = "0.12.0", features = ["samd21g", "rtic", "unproven"] }
 xiao_m0 = {version = "0.9.0", features = ["unproven"]}
 panic-halt = "0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,10 +120,13 @@ mod app {
         debounce::spawn_after(Milliseconds(30_u32)).ok();
     }
 
-    #[task(shared = [modeDetectPin])]
+    #[task(shared = [modeDetectPin], local = [
+        hold: Option<hold::SpawnHandle> = None,
+        pressed_at: Option<Instant<RtcMonotonic>> = None
+    ])]
     fn debounce(mut cx: debounce::Context){
-        static mut HOLD: Option<hold::SpawnHandle> = None;
-        static mut PRESSED_AT: Option<Instant<RtcMonotonic>> = None;
+        let HOLD: &'static mut Option<hold::SpawnHandle> = cx.local.hold;
+        let PRESSED_AT: &'static mut Option<Instant<RtcMonotonic>> = cx.local.pressed_at;
         if let Some(handle) = HOLD.take() {
             handle.cancel().ok();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ mod app {
         ledString: ws2812<hal::sercom::SPIMaster0<Sercom0Pad1<Pa5<PfD>>, Sercom0Pad2<Pa6<PfD>>, Sercom0Pad3<Pa7<PfD>>>>,
         button: ExtInt8<Pb8<PfA>>,
         modeDetectPin: Pa11<Input<Floating>>,
-        colors: core::iter::Cycle<<heapless::Vec<[smart_leds::RGB<u8>; 35], 5_usize> as IntoIterator>::IntoIter>,
+        colors: core::iter::Cycle<<heapless::Vec<[smart_leds::RGB<u8>; 20], 5_usize> as IntoIterator>::IntoIter>,
         adc: atsamd_hal::adc::Adc<hal::pac::ADC>,
         controlKnob: Pa10<PfB>,
     }
@@ -41,7 +41,7 @@ mod app {
 
     #[init]
     fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
-        const NUM_LEDS: usize = 35;
+        const NUM_LEDS: usize = 20;
         let mut peripherals = cx.device;
         let mut pins = hal::Pins::new(peripherals.PORT);
         let mut clocks = GenericClockController::with_external_32kosc(
@@ -166,7 +166,7 @@ mod app {
             let data: u16 = _adc.read(_controlKnob).unwrap();
             let data: u8 = ( data >> 4) as u8;
             rprintln!("brightness value: {}", data);
-            let newColor: Option<[RGB8; 35]> = _colors.next();
+            let newColor: Option<[RGB8; 20]> = _colors.next();
             if let Some(i) = newColor {
                 _ledString.write(brightness(i.iter().cloned(), data)).unwrap();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![no_main]
 #![no_std]
+#![allow(non_snake_case)]
 
 extern crate xiao_m0 as hal;
 use panic_rtt_target as _;
@@ -125,8 +126,8 @@ mod app {
         pressed_at: Option<Instant<RtcMonotonic>> = None
     ])]
     fn debounce(mut cx: debounce::Context){
-        let HOLD: &'static mut Option<hold::SpawnHandle> = cx.local.hold;
-        let PRESSED_AT: &'static mut Option<Instant<RtcMonotonic>> = cx.local.pressed_at;
+        let HOLD = cx.local.hold;
+        let PRESSED_AT = cx.local.pressed_at;
         if let Some(handle) = HOLD.take() {
             handle.cancel().ok();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ mod app {
         rtt_init_print!();
         rprintln!("Initialization complete!");
 
-        ( Local {}, Shared { ledString, button, modeDetectPin, colors, adc, controlKnob }, init::Monotonics(rtc)) }
+        ( Shared { ledString, button, modeDetectPin, colors, adc, controlKnob }, Local {}, init::Monotonics(rtc)) }
 
       // Optional idle task, if left out idle will be a WFI.
     #[idle]
@@ -153,14 +153,18 @@ mod app {
 
     #[task(shared = [ledString, colors, adc, controlKnob])]
     fn writeLeds(cx: writeLeds::Context){
-        let writeLeds::Shared {ledString, colors, adc, controlKnob } = cx.shared;
-        (ledString, colors, adc, controlKnob).lock(|leds, colors, adc, controlKnob| {
-            let data: u16 = adc.read(controlKnob).unwrap();
+        let _ledString = cx.shared.ledString;
+        let _colors = cx.shared.colors;
+        let _adc = cx.shared.adc;
+        let _controlKnob = cx.shared.controlKnob;
+
+        (_ledString, _colors, _adc, _controlKnob).lock(|_ledString, _colors, _adc, _controlKnob| {
+            let data: u16 = _adc.read(_controlKnob).unwrap();
             let data: u8 = ( data >> 4) as u8;
             rprintln!("brightness value: {}", data);
-            let newColor: Option<[RGB8; 35]> = colors.next();
+            let newColor: Option<[RGB8; 35]> = _colors.next();
             if let Some(i) = newColor {
-                leds.write(brightness(i.iter().cloned(), data)).unwrap();
+                _ledString.write(brightness(i.iter().cloned(), data)).unwrap();
             }
         });
     }


### PR DESCRIPTION
migrates to `rtic-0.6.0-alpha.5`.

Note, type and lifetime annotations currently left out for `HOLD` and `PRESSED_AT` locals in `debounce` task, pending identification of either bug or user error related to https://github.com/rtic-rs/cortex-m-rtic/issues/524